### PR TITLE
Add new VS2015 temp file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ dlldata.c
 *.pidb
 *.svclog
 *.scc
+*.VC.opendb
 
 # Visual Studio output directories
 Debug*/


### PR DESCRIPTION
a .VC.opendb file is created while the solution is open in VS2015 Update 1. Updating the .gitignore to include this file.
