### PR TITLE
Fix For Newer VS 2019

### DIFF
--- a/Vimeo-Native/Include/Vimeo/VimeoAPI.h
+++ b/Vimeo-Native/Include/Vimeo/VimeoAPI.h
@@ -25,32 +25,32 @@ public:
    virtual bool GetCanceled()                   = 0;
 };
 
-typedef int (*PVIMEO_CREATE_FUNC)                        (VimeoHandle* ppHandle, VimeoString* pstrClientID, VimeoString* pstrClientSecret);
+typedef int (*PVIMEO_CREATE_FUNC)                        (VimeoHandle* ppHandle, const VimeoString* pstrClientID, const VimeoString* pstrClientSecret);
 typedef int (*PVIMEO_FREE_FUNC)                          (VimeoHandle* ppHandle);
-typedef int (*PVIMEO_LOADAUTHORIZATIONTOKEN_FUNC)        (VimeoHandle pHandle, VimeoString* pstrAuthToken);
+typedef int (*PVIMEO_LOADAUTHORIZATIONTOKEN_FUNC)        (VimeoHandle pHandle, const VimeoString* pstrAuthToken);
 typedef int (*PVIMEO_GETAUTHORIZATIONURL_FUNC)           (VimeoHandle pHandle, VimeoString* pstrURL, int& nSizeOfURL);
 typedef int (*PVIMEO_GETUSERNAME_FUNC)                   (VimeoHandle pHandle, VimeoString* pstrUserName, int& nSizeOfUserName);
 
 typedef int (*PVIMEO_GETURL_FUNC)                        (VimeoHandle pHandle, VimeoString *pstrURL, int& nSizeOfURL);
-typedef int (*PVIMEO_ISCALLBACKURL_FUNC)                 (VimeoString* pstrURL);
+typedef int (*PVIMEO_ISCALLBACKURL_FUNC)                 (const VimeoString* pstrURL);
 typedef int (*PVIMEO_OBTAINACCESSTOKEN_FUNC)             (VimeoHandle pHandle, VimeoString* pstrURL);
 typedef int (*PVIMEO_GETACCESSTOKEN_FUNC)                (VimeoHandle pHandle, VimeoString *pstrAccessToken, int& nSizeOfAccessToken);
 
-typedef int (*PVIMEO_UPLOADFILE_FUNC)                    (VimeoHandle pHandle, VimeoString* pstrPath, VimeoString* pstrTitle, VimeoString* pstrDescription, VimeoString* pstrTags, int nPrivacy, VimeoString* pstrPrivacy, IVimeoProgress* pProgress);
+typedef int (*PVIMEO_UPLOADFILE_FUNC)                    (VimeoHandle pHandle, const VimeoString* pstrPath, const VimeoString* pstrTitle, const VimeoString* pstrDescription, const VimeoString* pstrTags, int nPrivacy, const VimeoString* pstrPrivacy, IVimeoProgress* pProgress);
 typedef int (*PVIMEO_GETERRORMESSAGE_FUNC)               (VimeoHandle pHandle, VimeoString* pstrMessage, int& nSizeOfMessage);
 
-VIMEO_EXTERN int VimeoCreate(VimeoHandle* ppHandle, VimeoString* pstrClientID, VimeoString* pstrClientSecret);
+VIMEO_EXTERN int VimeoCreate(VimeoHandle* ppHandle, const VimeoString* pstrClientID, const VimeoString* pstrClientSecret);
 VIMEO_EXTERN int VimeoFree(VimeoHandle* ppHandle);
-VIMEO_EXTERN int VimeoLoadAccessToken(VimeoHandle pHandle, VimeoString* pstrAuthToken);
+VIMEO_EXTERN int VimeoLoadAccessToken(VimeoHandle pHandle, const VimeoString* pstrAuthToken);
 VIMEO_EXTERN int VimeoGetUserAuthorizationURL(VimeoHandle pHandle, VimeoString* pstrURL, int& nSizeOfURL);
 VIMEO_EXTERN int VimeoGetUserName(VimeoHandle pHandle, VimeoString* pstrUserName, int& nSizeOfUserName);
 
 VIMEO_EXTERN int VimeoGetURL(VimeoHandle pHandle, VimeoString *pstrURL, int& nSizeOfURL);
-VIMEO_EXTERN int VimeoIsCallbackURL(VimeoString* pstrURL);
+VIMEO_EXTERN int VimeoIsCallbackURL(const VimeoString* pstrURL);
 VIMEO_EXTERN int VimeoObtainAccessToken(VimeoHandle pHandle, VimeoString* pstrURL);
 VIMEO_EXTERN int VimeoGetAccessToken(VimeoHandle pHandle, VimeoString *pstrAccessToken, int& nSizeOfAccessToken);
 
-VIMEO_EXTERN int VimeoUploadFile(VimeoHandle pHandle, VimeoString* pstrPath, VimeoString* pstrTitle, VimeoString* pstrDescription, VimeoString* pstrTags, int nPrivacy, VimeoString* pstrPrivacy, IVimeoProgress* pProgress);
+VIMEO_EXTERN int VimeoUploadFile(VimeoHandle pHandle, const VimeoString* pstrPath, const VimeoString* pstrTitle, const VimeoString* pstrDescription, const VimeoString* pstrTags, int nPrivacy, const VimeoString* pstrPrivacy, IVimeoProgress* pProgress);
 VIMEO_EXTERN int VimeoGetErrorMessage(VimeoHandle pHandle, VimeoString* pstrMessage, int& nSizeOfMessage);
 
 #endif

--- a/Vimeo-Native/VimeoInterop/VimeoInterop.h
+++ b/Vimeo-Native/VimeoInterop/VimeoInterop.h
@@ -21,7 +21,7 @@ public:
    static System::Collections::Generic::IDictionary<int, VimeoAPI::Vimeo^> ^ _GCLibMap = gcnew System::Collections::Generic::Dictionary<int, VimeoAPI::Vimeo^>();
 };
 
-VIMEO_EXTERN int VimeoCreate(VimeoHandle* ppHandle, VimeoString* pstrClientID, VimeoString* pstrClientSecret)
+VIMEO_EXTERN int VimeoCreate(VimeoHandle* ppHandle, const VimeoString* pstrClientID, const VimeoString* pstrClientSecret)
 {
    String ^strClientID     = gcnew String(pstrClientID);
    String ^strClientSecret = gcnew String(pstrClientSecret);
@@ -46,7 +46,7 @@ VIMEO_EXTERN int VimeoFree(VimeoHandle* ppHandle)
    return VIMEO_SUCCESS;
 }
 
-VIMEO_EXTERN int VimeoLoadAccessToken(VimeoHandle pHandle, VimeoString* pstrAuthToken)
+VIMEO_EXTERN int VimeoLoadAccessToken(VimeoHandle pHandle, const VimeoString* pstrAuthToken)
 {
    String ^strAuthToken     = gcnew String(pstrAuthToken);
    VimeoAPI::Vimeo^ pVimeo = GET_LIB(pHandle);
@@ -108,7 +108,7 @@ VIMEO_EXTERN int VimeoGetURL(VimeoHandle pHandle, VimeoString *pstrURL, int& nSi
    return bOK ? VIMEO_SUCCESS : VIMEO_FAILURE_GENERIC;
 }
 
-VIMEO_EXTERN int VimeoIsCallbackURL(VimeoString* pstrURL)
+VIMEO_EXTERN int VimeoIsCallbackURL(const VimeoString* pstrURL)
 {
    String ^strURL     = gcnew String(pstrURL);
    bool bOK = VimeoAPI::Vimeo::StartsWithCallbackURL(strURL);
@@ -167,7 +167,7 @@ inline System::Boolean IVimeoProgressAdapter::GetCanceled()
    return m_pProgress ? m_pProgress->GetCanceled() : false;
 }
 
-VIMEO_EXTERN int VimeoUploadFile(VimeoHandle pHandle, VimeoString* pstrPath, VimeoString* pstrTitle, VimeoString* pstrDescription, VimeoString* pstrTags, int nPrivacy, VimeoString* pstrPassword, IVimeoProgress* pProgress)
+VIMEO_EXTERN int VimeoUploadFile(VimeoHandle pHandle, const VimeoString* pstrPath, const VimeoString* pstrTitle, const VimeoString* pstrDescription, const VimeoString* pstrTags, int nPrivacy, const VimeoString* pstrPassword, IVimeoProgress* pProgress)
 {
    String ^strPath         = gcnew String(pstrPath);
    String ^strTitle        = gcnew String(pstrTitle);

--- a/Vimeo-Native/VimeoNative.autopkg
+++ b/Vimeo-Native/VimeoNative.autopkg
@@ -11,7 +11,7 @@ nuget
    nuspec
    {
       id = VimeoNative;
-      version: 11.0.0.0;
+      version: 11.1.0.0;
       title: Vimeo Native Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -24,6 +24,7 @@ nuget
       description: @"A Vimeo library which acts as an interface via interop to the C# Vimeo libraries.
 
 New features:
+    v 11.1.0.0 Updated some functions to take a const wchar_t*s
     v 11.0.0.0 Updated to use Visual Studio 2017
     v 10.0.0.0 Updated to use Visual Studio 2015/.NET 4.6
 Breaking changes:
@@ -32,7 +33,7 @@ Breaking changes:
 Bugfixes:
 Misc:
       ";
-      copyright: "Copyright (c) 2014-2018 TechSmith Corporation. All rights reserved.";
+      copyright: "Copyright (c) 2014 TechSmith Corporation. All rights reserved.";
       tags: { native, tsc, vimeo, utility, vs2017, cpp, dynamicmfc, mfc, dynamiccpp };
    };
 


### PR DESCRIPTION
## Introduction

This is to help build with newer Visual Studio 2019.

Vimeo takes some strings; and the way we accepted them gave the impressions that we could write over the strings.  Based on how they are intended to be used they should have been `const` strings:
![image](https://user-images.githubusercontent.com/3475163/108220608-e8888100-7104-11eb-8ff5-b001deb799a1.png)

## Details

The Vimeo code purposely takes a raw string type (e.g. `const wchar_t*`) instead of a `std::string` such that it enables it to work with more clients.  A `VimeoString` is a typedef such that in one place we could switch from `wchar_t` to `char` if desired.  But these strings should be `const` unless we are allowing the ability to write over the data that these strings are pointing to.  We are not.  Some strings are non-`const` where it will write to them.

These changes only fix the strings.  It doesn't update this project to VS 2019 or anything like that.

Hope that helps! :smiley: